### PR TITLE
feat: add JS/VM pool Prometheus metrics

### DIFF
--- a/internal/imposter/inject.go
+++ b/internal/imposter/inject.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/TetsujinOni/go-tartuffe/internal/metrics"
 	"github.com/TetsujinOni/go-tartuffe/internal/models"
 	"github.com/dop251/goja"
 )
@@ -225,7 +227,9 @@ func (e *JSEngine) ExecuteResponse(script string, req *models.Request, imposterS
 		return nil, formatJSError(err, script, formatRequestInfo(req))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("response", time.Since(jsStart).Seconds())
 	if err != nil {
 		return nil, formatJSError(err, script, formatRequestInfo(req))
 	}
@@ -313,7 +317,9 @@ func (e *JSEngine) ExecutePredicate(script string, req *models.Request, imposter
 		return false, formatJSError(err, script, formatRequestInfo(req))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("predicate", time.Since(jsStart).Seconds())
 	if err != nil {
 		return false, formatJSError(err, script, formatRequestInfo(req))
 	}
@@ -444,7 +450,9 @@ func (e *JSEngine) ExecutePredicateGenerator(script string, req *models.Request)
 		return nil, formatJSError(err, script, formatRequestInfo(req))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("predicate_generator", time.Since(jsStart).Seconds())
 	if err != nil {
 		return nil, formatJSError(err, script, formatRequestInfo(req))
 	}
@@ -487,7 +495,9 @@ func (e *JSEngine) ExecuteEndOfRequestResolver(script string, rawData []byte, is
 			return false, formatJSError(err, script, dataPreview)
 		}
 
+		jsStart := time.Now()
 		result, err := vm.RunProgram(program)
+		metrics.RecordJSExecution("end_of_request", time.Since(jsStart).Seconds())
 		if err != nil {
 			dataPreview := fmt.Sprintf("[binary data, %d bytes]", len(rawData))
 			return false, formatJSError(err, script, dataPreview)
@@ -517,7 +527,9 @@ func (e *JSEngine) ExecuteEndOfRequestResolver(script string, rawData []byte, is
 		return false, formatJSError(err, script, fmt.Sprintf("requestData: %q", dataPreview))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("end_of_request", time.Since(jsStart).Seconds())
 	if err != nil {
 		dataPreview := requestData
 		if len(dataPreview) > 50 {
@@ -581,7 +593,9 @@ func (e *JSEngine) ExecuteTCPPredicate(script string, requestData string) (bool,
 		return false, formatJSError(err, script, fmt.Sprintf("TCP data: %q", dataPreview))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("tcp_predicate", time.Since(jsStart).Seconds())
 	if err != nil {
 		// Include preview of request data for debugging
 		dataPreview := requestData
@@ -651,7 +665,9 @@ func (e *JSEngine) ExecuteTCPResponse(script string, requestData string, state m
 		return "", formatJSError(err, script, fmt.Sprintf("TCP data: %q", dataPreview))
 	}
 
+	jsStart := time.Now()
 	result, err := vm.RunProgram(program)
+	metrics.RecordJSExecution("tcp_response", time.Since(jsStart).Seconds())
 	if err != nil {
 		// Include preview of request data for debugging
 		dataPreview := requestData

--- a/internal/imposter/vmpool.go
+++ b/internal/imposter/vmpool.go
@@ -3,6 +3,7 @@ package imposter
 import (
 	"sync"
 
+	"github.com/TetsujinOni/go-tartuffe/internal/metrics"
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/buffer"
 	"github.com/dop251/goja_nodejs/console"
@@ -32,6 +33,7 @@ func NewVMPool() *VMPool {
 
 // createVM creates a new configured Goja VM with all required modules enabled.
 func (vp *VMPool) createVM() interface{} {
+	metrics.RecordVMCreated()
 	vm := goja.New()
 	vp.registry.Enable(vm)
 	buffer.Enable(vm)
@@ -41,6 +43,7 @@ func (vp *VMPool) createVM() interface{} {
 
 // Acquire gets a VM from the pool. The caller must call Release when done.
 func (vp *VMPool) Acquire() *goja.Runtime {
+	metrics.RecordVMAcquire()
 	return vp.pool.Get().(*goja.Runtime)
 }
 
@@ -49,6 +52,7 @@ func (vp *VMPool) Acquire() *goja.Runtime {
 func (vp *VMPool) Release(vm *goja.Runtime) {
 	vp.resetVM(vm)
 	vp.pool.Put(vm)
+	metrics.RecordVMRelease()
 }
 
 // resetVM clears VM global state between uses.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -88,6 +88,31 @@ var (
 		},
 		[]string{"imposter"},
 	)
+
+	// JSVMCreatedTotal counts new Goja VM allocations by the pool
+	JSVMCreatedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "mb_js_vm_created_total",
+		Help: "Total number of new JavaScript VMs created by the pool.",
+	})
+
+	// JSVMAcquiresTotal counts VM checkouts from the pool (one per JS execution)
+	JSVMAcquiresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "mb_js_vm_acquires_total",
+		Help: "Total number of JavaScript VM acquisitions from the pool.",
+	})
+
+	// JSVMsInUse tracks the number of VMs currently checked out
+	JSVMsInUse = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "mb_js_vms_in_use",
+		Help: "Current number of JavaScript VMs checked out from the pool.",
+	})
+
+	// JSExecutionDuration tracks JS script execution time, labelled by script type
+	JSExecutionDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "mb_js_execution_duration_seconds",
+		Help:    "Duration of JavaScript script execution in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"script_type"})
 )
 
 // RecordRequest records a request to an imposter
@@ -136,6 +161,21 @@ func RecordNoMatch(endpoint, port string) {
 // SetStubsCount sets the number of stubs for an imposter
 func SetStubsCount(port string, count int) {
 	StubsTotal.WithLabelValues(port).Set(float64(count))
+}
+
+// RecordVMCreated records a new Goja VM allocation by the pool.
+func RecordVMCreated() { JSVMCreatedTotal.Inc() }
+
+// RecordVMAcquire records a VM checkout from the pool.
+func RecordVMAcquire() { JSVMAcquiresTotal.Inc(); JSVMsInUse.Inc() }
+
+// RecordVMRelease records a VM being returned to the pool.
+func RecordVMRelease() { JSVMsInUse.Dec() }
+
+// RecordJSExecution records the duration of a JavaScript script execution.
+// scriptType identifies the kind of script (e.g. "response", "predicate", "tcp_response").
+func RecordJSExecution(scriptType string, duration float64) {
+	JSExecutionDuration.WithLabelValues(scriptType).Observe(duration)
 }
 
 // RemoveImposterMetrics removes metrics for a deleted imposter


### PR DESCRIPTION
Port JS and VM pool metrics from chore/tuning:
- mb_js_vm_created_total, mb_js_vm_acquires_total, mb_js_vms_in_use
- mb_js_execution_duration_seconds (labelled by script_type)

Instrument VMPool.createVM/Acquire/Release and all JSEngine.Execute* call sites.